### PR TITLE
Personal access tokens

### DIFF
--- a/notebooks/Connections.md
+++ b/notebooks/Connections.md
@@ -35,7 +35,7 @@ Step 2 - Click on the **Setting** menu.
 
 Step 3 - From the Setting menu click on **Developer Settings**
 
-Step 4 - From the Developer Settings menu, click on **Personal access token**
+Step 4 - From the Developer Settings menu, click on **Personal access token**. For this class, select "Tokens (Classic)", not "Fine-grained tokens".
 
 Step 5 - From the Personal access token, click on the **Generate new Token button**.
 

--- a/notebooks/On_the_day_create_Rmarkdown_make_commit_changes_using_RStudio.md
+++ b/notebooks/On_the_day_create_Rmarkdown_make_commit_changes_using_RStudio.md
@@ -41,9 +41,12 @@ Click the green arrow "Push" button to send your local changes to GitHub.
 
 <img src="../fig/push_final.png" style="width:100%; height:100%;"/>
 
-Ideally you should not experience any issue when pushing the changes to the github server as you have previously done similar push from the command line  
+Ideally you should not experience any issue when pushing the changes to the github server as you have previously done similar push from the command line
 
 The RStudio's Git pane provides a specific subset of command line Git through its interface. So, if your credentials work in the shell, they should work in RStudio  
+
+Note that if RStudio asks for your Git username and password, you should use your
+Personal Access Token as the password, not your GitHub password.
 
 ### **Confirm the local change propagated to the GitHub remote**
 

--- a/notebooks/On_the_day_create_a_test_repo.md
+++ b/notebooks/On_the_day_create_a_test_repo.md
@@ -101,3 +101,7 @@ Push the changes to github `git push`.
 
 The local changes should now be reflected into the `README.md` file on the github repo.
 Please check them.
+
+Note that if `git push` asks for your GitHub username and password, you should use your
+Personal Access Token as the password, not your GitHub password.
+


### PR DESCRIPTION
Added some reminders that when github asks for a password it expects a personal access token, and also mentioned that there's now two kinds of access token (fine-grained and classic) in the setup