### PR TITLE
Use a link to the Presentation

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -19,7 +19,7 @@ website:
       - text: "Git for version control"
         menu:
         - text: "Presentation"
-          href: "https://unisyd.sharepoint.com/:p:/r/teams/SydneyInformaticsHub2/_layouts/15/Doc.aspx?sourcedoc=%7BA2B9FBEB-02BA-4410-A516-A4B81F449F29%7D&file=Rstudio%20and%20github.pptx&action=edit&mobileredirect=true"
+          href: "notebooks/Presentation.md"
         - text: "Check prerequisites"
           href: notebooks/On_the_day_check_prerequisites.md
         - text: "Create a test repo in github"

--- a/notebooks/Presentation.md
+++ b/notebooks/Presentation.md
@@ -1,0 +1,11 @@
+---
+fig-cap-location: top
+from: markdown+emoji
+---
+
+# **Background on Git and R**
+
+
+</br>
+
+Follow along the presentation [here!](https://unisyd.sharepoint.com/:p:/r/teams/SydneyInformaticsHub2/_layouts/15/Doc.aspx?sourcedoc=%7BA2B9FBEB-02BA-4410-A516-A4B81F449F29%7D&file=Rstudio%20and%20github.pptx&action=edit&mobileredirect=true) <br>


### PR DESCRIPTION
Added presentation link to its own page for consistent worfklow, so users do not get taken away from github pages.